### PR TITLE
Add README for corpus data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ CuRIAM stands for Corpus re Interpretation and Metalanguage. For information abo
 
 
 ## Corpus Data
-The full corpus data is available [here](/corpus/).
+The full corpus data is available [here](/corpus/) and recommended for programmatic exploration of the data.
+
+## Exploring Data
+`data/main/annotated` contains the exports from annotation software and the verticalised `*.tsv` can be used to manually explore texts and their annotation.
 
 ## Setup
 1. Create a conda environment.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,32 @@
+# Corpus Data of CuRIAM
+
+The corpus data is available in `JSON` format. The JSON is a list of the 41 annotated opinion `documents`. 
+* Each `document` consists of a `name` and as a list of annotated `sentences`.
+* Each `sentence` has `id` and the list of `tokens`. 
+* Each `token` has an `id` and `text` and has `annotation`s (considered unordered for now).
+* Each `annotation` has an `id` indicating a BIO indication of the tagged chunk since labels can overlap.
+
+Below is a reference structure.
+
+```
+[{
+    "name": "<document>"
+    "sentences": [
+        {
+            "id" : "<id>",
+            "tokens" : [
+                {
+                    "text": "<text>",
+                    "annotations": [
+                        {
+                            "id" : "<BIO tag>",
+                            "category" : "<Curium-Category>"
+                        }
+                    ]                   
+                }
+            ]           
+        }
+    ]   
+}]
+```
+ 


### PR DESCRIPTION
Added a README for `corpus/` explaining the json structure. 
Updated the main README to recommend `data/main/annotated` for manual exploration. 